### PR TITLE
Add with_context class method to the serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem "puma"
 
-gem "sqlite3"
+gem "sqlite3", "~> 1.7.3"
 
 gem "standard", "~> 1.3", group: :development
 gem "debug", ">= 1.0.0", group: :development

--- a/README.md
+++ b/README.md
@@ -200,6 +200,25 @@ Feel like using a block to define your associations? You can do that too.
   end
 ```
 
+## Context
+You can pass a context to the serializer with the `with_context` method.
+
+```ruby
+serializer = PostSerializer.new(Post.last).with_context(current_user: current_user)
+```
+
+This context will be available in the serializer with the `context` method.
+
+```ruby
+class PostSerializer < Barley::Serializer
+  attributes :id, :title, :body
+
+  attribute :is_owner do
+    object.user == context.current_user
+  end
+end
+```
+
 ## Generators
 You have two generators available. One to generate the serializer class:
 

--- a/lib/barley/serializer.rb
+++ b/lib/barley/serializer.rb
@@ -3,6 +3,7 @@
 module Barley
   class Serializer
     attr_accessor :object
+    attr_accessor :context
 
     class << self
       attr_accessor :defined_attributes
@@ -222,6 +223,25 @@ module Barley
     # @return [Boolean] whether the cache was cleared
     def clear_cache(key: cache_base_key)
       Barley::Cache.delete(key)
+    end
+
+    # Sets the context object for the serializer
+    #
+    # The context object is a Struct built from the given arguments.
+    # It can be used to pass additional data to the serializer. The context object is accessible in the serializer with the `context` attribute.
+    # @example
+    #   serializer.with_context(current_user: current_user, locale: I18n.locale)
+    #   # => #<Barley::Serializer:0x00007f8f3b8b3e08 @object=#<Product id: 1, name: "Product 1">, @context=#<struct current_user=1, locale=:en>>
+    #   # In the serializer:
+    #   attribute :name do
+    #     "#{object.name[context.locale]}" # Will use the locale from the context
+    #   end
+    # @param args [Hash] the context object attributes
+    # @return [Barley::Serializer] the serializer
+    def with_context(**args)
+      @context = Struct.new(*args.keys).new(*args.values)
+
+      self
     end
 
     private

--- a/sig/barley/serializer.rbs
+++ b/sig/barley/serializer.rbs
@@ -1,10 +1,12 @@
 module Barley
 class Serializer
   @cache: bool
+  @context: Struct[untyped]
   @expires_in: ActiveSupport::Duration
   @root: bool
 
   attr_accessor self.defined_attributes: Array[Symbol]
+  attr_accessor context: Struct[untyped]
   attr_accessor object: ActiveRecord::Base
   def self.attributes: (*(Symbol | Hash[Symbol, untyped]) keys) -> untyped
   def self.attribute: (Symbol key, ?key_name: Symbol | nil, ?type: nil) ?{ () -> void } -> [untyped]
@@ -14,6 +16,7 @@ class Serializer
   def initialize: (untyped object, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?root: bool) -> void
   def serializable_hash: -> Hash[Symbol, untyped]
   def clear_cache: (?key: String) -> untyped
+  def with_context:(*(Hash[Symbol, untyped])) -> self
 
   private
   def cache_base_key: -> String

--- a/test/barley/serializer_test.rb
+++ b/test/barley/serializer_test.rb
@@ -120,5 +120,21 @@ module Barley
         serializer.new(@user).serializable_hash
       end
     end
+
+    test "it serializes with context" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        attribute :note do
+          context[:note]
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        note: "new note"
+      }
+      assert_equal(expected, serializer.new(@user).with_context(note: "new note").serializable_hash)
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR adds a `with_context` method to the `Barley::Serializer` class.

This allows you to use context in your serializer:
```ruby
attribute :name do
  "#{object.name[context.locale]}" # Will use the locale from the context
end
```

So that when you can do

```ruby
serializer.with_context(current_user: current_user, locale: I18n.locale)
# => #<Barley::Serializer:0x00007f8f3b8b3e08 @object=#<Product id: 1, name: "Product 1">, @context=#<struct current_user=1, locale=:en>>
```

And you get access to `current_user` and `locale` with the `context.*` shorthands.

## Type of change

Please delete options that are not relevant.

- [~] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [~] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added a test in SerializerTest

- [x] Barley::SerializerTest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

