### PR TITLE
Add context argument to Serializer initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,14 @@ Feel like using a block to define your associations? You can do that too.
 ```
 
 ## Context
+
 You can pass a context to the serializer with the `with_context` method.
 
 ```ruby
 serializer = PostSerializer.new(Post.last).with_context(current_user: current_user)
 ```
 
-This context will be available in the serializer with the `context` method.
+This context will be available in the serializer with the `context` method. It is also available in nested serializers.
 
 ```ruby
 class PostSerializer < Barley::Serializer
@@ -216,7 +217,24 @@ class PostSerializer < Barley::Serializer
   attribute :is_owner do
     object.user == context.current_user
   end
+  
+  many :comments do
+    many :likes do
+      attribute :is_owner do
+        object.user == context.current_user # context is here too!
+      end
+    end
+  end
 end
+```
+
+### Using a custom context object
+Barley generates a Struct from the context hash you pass to the with_context method. But you can also pass a custom context object directly in the initializer instead.
+
+```ruby
+my_context = Struct.new(:current_user).new(current_user)
+
+serializer = PostSerializer.new(Post.last, context: my_context)
 ```
 
 ## Generators

--- a/lib/barley/serializer.rb
+++ b/lib/barley/serializer.rb
@@ -128,7 +128,7 @@ module Barley
           return {} if element.nil?
 
           el_serializer = serializer || element.serializer.class
-          el_serializer.new(element, cache: cache).serializable_hash
+          el_serializer.new(element, cache: cache, context: @context).serializable_hash
         end
         self.defined_attributes = (defined_attributes || []) << key_name
       end
@@ -178,7 +178,7 @@ module Barley
           return [] if elements.empty?
 
           el_serializer = serializer || elements.first.serializer.class
-          elements.map { |element| el_serializer.new(element, cache: cache).serializable_hash }.reject(&:blank?)
+          elements.map { |element| el_serializer.new(element, cache: cache, context: @context).serializable_hash }.reject(&:blank?)
         end
         self.defined_attributes = (defined_attributes || []) << key_name
       end
@@ -193,8 +193,10 @@ module Barley
     # @param object [Object] the object to serialize
     # @param cache [Boolean, Hash<Symbol, ActiveSupport::Duration>] a boolean to cache the result, or a hash with options for the cache
     # @param root [Boolean] whether to include the root key in the hash
-    def initialize(object, cache: false, root: false)
+    # @param context [Object] an optional context object to pass additional data to the serializer
+    def initialize(object, cache: false, root: false, context: nil)
       @object = object
+      @context = context
       @root = root
       @cache, @expires_in = if cache.is_a?(Hash)
         [true, cache[:expires_in]]

--- a/sig/barley/serializer.rbs
+++ b/sig/barley/serializer.rbs
@@ -1,7 +1,7 @@
 module Barley
 class Serializer
   @cache: bool
-  @context: Struct[untyped]
+  @context: untyped
   @expires_in: ActiveSupport::Duration
   @root: bool
 
@@ -13,7 +13,7 @@ class Serializer
   def self.one: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration]) ?{ () -> void } -> (Hash[untyped, untyped] | [untyped])
   def self.many: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration]) ?{ () -> void } -> Array[untyped]
   def self.set_class_iv: (Symbol iv, Symbol key) -> [untyped]
-  def initialize: (untyped object, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?root: bool) -> void
+  def initialize: (untyped object, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?root: bool, ?context: untyped) -> void
   def serializable_hash: -> Hash[Symbol, untyped]
   def clear_cache: (?key: String) -> untyped
   def with_context:(*(Hash[Symbol, untyped])) -> self

--- a/test/barley/serializer_test.rb
+++ b/test/barley/serializer_test.rb
@@ -126,7 +126,7 @@ module Barley
         attributes :id, :email
 
         attribute :note do
-          context[:note]
+          context.note
         end
       end
       expected = {
@@ -135,6 +135,23 @@ module Barley
         note: "new note"
       }
       assert_equal(expected, serializer.new(@user).with_context(note: "new note").serializable_hash)
+    end
+
+    test "it serializes with a context object given to the initializer" do
+      my_context = Struct.new(:note).new("new note")
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        attribute :note do
+          context.note
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        note: "new note"
+      }
+      assert_equal(expected, serializer.new(@user, context: my_context).serializable_hash)
     end
   end
 end


### PR DESCRIPTION
# Description

This MR adds the possibility to define a custom `context` object to pass to the initializer of the `Serializer`.

This change also allows the context to be available in nested `one` or `many` association blocks inside the serializer definition.

So now you can do

```ruby
class ProductSerializer < Barley::Serializer
  attribute :name do
    object.localized_name(context.locale)
   end

  many :storages do
    many :shelves do
      object.localized_name(context.locale) # context is available here too!
    end
  end
end
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] updated the `serializer_test.rb` file with relevant tests

# Benchmarks

Barley is fast, and should be kept as fast as possible. Provide benchmarks related to speed and memory footprint.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

