### PR TITLE
Add a `scope` argument to the `many` definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ class UserSerializer < Barley::Serializer
 
   many :posts
   
+  many :posts, key_name: :featured, scope: :featured
+  
+  many :posts, key_name: :popular, scope: -> { where("views > 10_000").limit(3) }
+  
   one :group, serializer: CustomGroupSerializer
   
   many :related_users, key: :friends, cache: true
@@ -174,6 +178,17 @@ You can define a custom serializer for the association with the `serializer` opt
   many :posts, serializer: CustomPostSerializer, cache: { expires_in: 1.hour }
 ```
 
+##### Scope
+You can pass a scope to the association with the `scope` option. It can either be a symbol referencing a named scope on your associated model, or a lambda.
+
+```ruby
+  many :posts, scope: :published # given you have a scope named `published` on your Post model
+```
+
+```ruby
+  many :posts, scope: -> { where(published: true).limit(4) }
+```
+
 ##### Key name
 You can also pass a key name for the association with the `key_name` option.
 
@@ -197,6 +212,14 @@ Feel like using a block to define your associations? You can do that too.
     one :author do
       attributes :name, :email
     end
+  end
+```
+
+Of course, all the options available for the `one` and `many` macros are also available for the block syntax.
+
+```ruby
+  many :posts, key_name: :featured do
+    attributes :id, :title, :body
   end
 ```
 

--- a/lib/barley/serializer.rb
+++ b/lib/barley/serializer.rb
@@ -161,12 +161,20 @@ module Barley
       #   many :groups, cache: {expires_in: 1.hour}
       #   # => {groups: [{id: 1234, name: "Group 1"}, {id: 5678, name: "Group 2"}]}
       #
+      # @example using a named scope
+      #   many :groups, scope: :active # given the scope `active` is defined in the Group model
+      #   # => {groups: [{id: 5678, name: "Group 2"}]}
+      #
+      # @example using a lambda scope
+      #   many :groups, scope: -> { order(id: :asc).limit(1) }
+      #   # => {groups: [{id: 1234, name: "Group 1"}]}
       # @param key [Symbol] the association name
       # @param key_name [Symbol] the key name in the hash
       # @param serializer [Class] the serializer to use
       # @param cache [Boolean, Hash<Symbol, ActiveSupport::Duration>] whether to cache the result, or a hash with options for the cache
+      # @param scope [Symbol] the scope to use to fetch the elements
       # @param block [Proc] a block to use to define the serializer inline
-      def many(key, key_name: nil, serializer: nil, cache: false, &block)
+      def many(key, key_name: nil, serializer: nil, cache: false, scope: nil, &block)
         key_name ||= key
         if block
           serializer = Class.new(Barley::Serializer) do

--- a/sig/barley/serializer.rbs
+++ b/sig/barley/serializer.rbs
@@ -11,7 +11,7 @@ class Serializer
   def self.attributes: (*(Symbol | Hash[Symbol, untyped]) keys) -> untyped
   def self.attribute: (Symbol key, ?key_name: Symbol | nil, ?type: nil) ?{ () -> void } -> [untyped]
   def self.one: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration]) ?{ () -> void } -> (Hash[untyped, untyped] | [untyped])
-  def self.many: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration]) ?{ () -> void } -> Array[untyped]
+  def self.many: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?scope: ^() -> void ) ?{ () -> void } -> Array[untyped]
   def self.set_class_iv: (Symbol iv, Symbol key) -> [untyped]
   def initialize: (untyped object, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?root: bool) -> void
   def serializable_hash: -> Hash[Symbol, untyped]

--- a/test/barley/serializer_test.rb
+++ b/test/barley/serializer_test.rb
@@ -136,5 +136,37 @@ module Barley
       }
       assert_equal(expected, serializer.new(@user).with_context(note: "new note").serializable_hash)
     end
+
+    test "it serializes a many association with a named scope" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups, scope: :active do
+          attributes :id, :name
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        groups: @user.groups.active.map { |g| {id: g.id, name: g.name} }
+      }
+      assert_equal(expected, serializer.new(@user).serializable_hash)
+    end
+
+    test "it serializes a many association with a lambda scope" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups, scope: -> { limit(1) } do
+          attributes :id, :name
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        groups: @user.groups.limit(1).map { |g| {id: g.id, name: g.name} }
+      }
+      assert_equal(expected, serializer.new(@user).serializable_hash)
+    end
   end
 end

--- a/test/dummy/app/models/group.rb
+++ b/test/dummy/app/models/group.rb
@@ -5,4 +5,6 @@ class Group < ApplicationRecord
 
   has_many :memberships
   has_many :users, through: :memberships
+
+  scope :active, -> { where(active: true) }
 end

--- a/test/dummy/db/migrate/20231009003811_create_groups.rb
+++ b/test/dummy/db/migrate/20231009003811_create_groups.rb
@@ -2,6 +2,7 @@ class CreateGroups < ActiveRecord::Migration[7.1]
   def change
     create_table :groups do |t|
       t.string :name
+      t.boolean :active, default: true
 
       t.timestamps
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema[7.1].define(version: 2023_10_09_012652) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
+    t.boolean "active", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/dummy/test/fixtures/groups.yml
+++ b/test/dummy/test/fixtures/groups.yml
@@ -2,6 +2,8 @@
 
 one:
   name: MyString
+  active: true
 
 two:
   name: MyString
+  active: false


### PR DESCRIPTION
# Description

This adds a `scope` argument to the `many` definition, that can either be a named scope defined on the associated model, or a lambda that will be called on the association. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (included)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added relevant tests to the `serializer_test.rb` file

# Benchmarks

Barley is fast, and should be kept as fast as possible. Provide benchmarks related to speed and memory footprint.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

