### PR TITLE
Raise a Barley::InvalidAttributeError on type errors

### DIFF
--- a/lib/barley.rb
+++ b/lib/barley.rb
@@ -15,6 +15,7 @@ module Barley
 
   autoload :Cache, "barley/cache"
   autoload :Error, "barley/error"
+  autoload :InvalidAttributeError, "barley/error"
   autoload :Serializable, "barley/serializable"
   autoload :Serializer, "barley/serializer"
 end

--- a/lib/barley/error.rb
+++ b/lib/barley/error.rb
@@ -3,4 +3,7 @@
 module Barley
   class Error < StandardError
   end
+
+  class InvalidAttributeError < Error
+  end
 end

--- a/lib/barley/serializer.rb
+++ b/lib/barley/serializer.rb
@@ -73,11 +73,18 @@ module Barley
       # @param key_name [Symbol] the key name in the hash
       # @param type [Dry::Types] the type to use, or coerce the value to
       # @param block [Proc] a block to use to compute the value
+      # @raise [Barley::InvalidAttributeError] if the value does not match the type - when a type is provided
       def attribute(key, key_name: nil, type: nil, &block)
         key_name ||= key
         define_method(key_name) do
           value = block ? instance_eval(&block) : object.send(key)
-          type.nil? ? value : type[value]
+          if type.nil?
+            value
+          else
+            raise Barley::InvalidAttributeError, "Invalid value type found for attribute #{key_name}::#{type.name}: #{value}::#{value.class}" unless type.valid?(value)
+
+            type[value]
+          end
         end
 
         self.defined_attributes = (defined_attributes || []) << key_name

--- a/test/dummy/app/lib/types.rb
+++ b/test/dummy/app/lib/types.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Types
+  include Dry.Types()
+end


### PR DESCRIPTION
# Description

Up to now, type errors raised by dry-types within a Barley serializer were not very clear and not easy to track.

This MR introduces a new `Barley::InvalidAttributeError` to handle type errors in attributes with the key name, the expected type and the actual type found.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] serializer_test.rb


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

