### PR TITLE
Add only and except filters, add context to scope lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v0.7.0 (2024-09-25)
+
+### ✨New features
+- Added the `only` and `except` options to the `attributes` method. This allows you to specify which attributes to include or exclude from the serialization. Will also work with nested associations.
+    ```ruby
+    class UserSerializer < Barley::Serializer
+        attributes :id, :name, :email
+    end
+
+    Serializer.new(User.last, only: [:id, :name]).serializable_hash
+    # => { id: 1, name: "John Doe" }
+    User.last.as_json(only: [:id, :name])
+    # => { id: 1, name: "John Doe" }
+    ```
+    ```ruby
+    class UserSerializer < Barley::Serializer
+        attributes :id, :name, :email
+    end
+
+    Serializer.new(User.last, except: [:email]).serializable_hash
+    # => { id: 1, name: "John Doe" }
+    ```
+    See the README for more details.
+- Added the possibility to pass the context to a `scope` proc / lambda in a `many` association.
+    ```ruby
+    class UserSerializer < Barley::Serializer
+        attributes :id, :name
+        many :posts, scope: ->(context) { where("language > ?", context[:language]) } do
+            attributes :id, :title
+        end
+    end
+
+    Serializer.new(User.last, context: {language: "en_US"}).serializable_hash
+    # => { id: 1, name: "John Doe", posts: [{ id: 1, title: "My first post" }] }
+    ```
+    See the README for more details.
+
 ## v0.6.2 (2024-06-17)
 
 ### ✨New features

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ class UserSerializer < Barley::Serializer
 
   many :posts, key_name: :popular, scope: -> { where("views > 10_000").limit(3) }
 
+  many :posts, key_name: :in_current_language, scope: -> (context) { where(language: context.language) }
+
   one :group, serializer: CustomGroupSerializer
 
   many :related_users, key: :friends, cache: true
@@ -59,7 +61,7 @@ Then just use the `as_json` method on your model.
 
 ```ruby
 user = User.find(1)
-user.as_json
+user.as_json(only: [:id, :name, posts: [:id, :title]])
 ```
 
 ## Installation
@@ -189,6 +191,12 @@ You can pass a scope to the association with the `scope` option. It can either b
   many :posts, scope: -> { where(published: true).limit(4) }
 ```
 
+You can also pass a context to the lambda. See the [context section](#context) for more details.
+
+```ruby
+  many :posts, scope: -> (context) { where(language: context.language) }
+```
+
 ##### Key name
 You can also pass a key name for the association with the `key_name` option.
 
@@ -249,6 +257,12 @@ class PostSerializer < Barley::Serializer
     end
   end
 end
+```
+
+The context is also available in the scope of the lambda passed to the `scope` option of the `many` macro. See the [scope section](#scope) for more details.
+
+```ruby
+  many :posts, scope: -> (context) { where(language: context.language) }
 ```
 
 ### Using a custom context object

--- a/lib/barley/serializable.rb
+++ b/lib/barley/serializable.rb
@@ -65,7 +65,7 @@ module Barley
         cache = options[:cache] || false
         root = options[:root] || false
         begin
-          serializer.new(self, cache: cache, root: root).serializable_hash
+          serializer.new(self, cache: cache, root: root, only: options[:only], except: options[:except]).serializable_hash
         rescue NameError
           raise Barley::Error, "Could not find serializer for #{self}. Please define a #{serializer} class."
         end

--- a/lib/barley/version.rb
+++ b/lib/barley/version.rb
@@ -1,3 +1,3 @@
 module Barley
-  VERSION = "0.6.2"
+  VERSION = "0.7"
 end

--- a/sig/barley/serializer.rbs
+++ b/sig/barley/serializer.rbs
@@ -3,6 +3,8 @@ class Serializer
   @cache: bool
   @context: untyped
   @expires_in: ActiveSupport::Duration
+  @only: Array[Symbol] | nil
+  @except: Array[Symbol] | nil
   @root: bool
 
   attr_accessor self.defined_attributes: Array[Symbol]
@@ -13,7 +15,7 @@ class Serializer
   def self.one: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration]) ?{ () -> void } -> (Hash[untyped, untyped] | [untyped])
   def self.many: (Symbol key, ?key_name: Symbol, ?serializer: Serializer, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?scope: ^() -> void ) ?{ () -> void } -> Array[untyped]
   def self.set_class_iv: (Symbol iv, Symbol key) -> [untyped]
-  def initialize: (untyped object, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?root: bool, ?context: untyped) -> void
+  def initialize: (untyped object, ?cache: bool | Hash[Symbol, ActiveSupport::Duration], ?root: bool, ?context: untyped, ?only: Array[Symbol], ?except: Array[Symbol]) -> void
   def serializable_hash: -> Hash[Symbol, untyped]
   def clear_cache: (?key: String) -> untyped
   def with_context:(*(Hash[Symbol, untyped])) -> self
@@ -24,6 +26,8 @@ class Serializer
   def _serializable_hash: -> Hash[Symbol, untyped]
 
   def root_key: -> Symbol
+  @only: untyped
+  @only: untyped
 end
 end
 

--- a/test/barley/serializable_test.rb
+++ b/test/barley/serializable_test.rb
@@ -29,7 +29,7 @@ module Barley
       mock = Minitest::Mock.new
       serializer_mock = Minitest::Mock.new
       mock.expect(:class, mock)
-      mock.expect(:new, serializer_mock, [model], cache: false, root: false)
+      mock.expect(:new, serializer_mock, [model], cache: false, root: false, only: nil, except: nil)
       serializer_mock.expect(:serializable_hash, {}, [])
 
       model.stub(:serializer, mock) do
@@ -55,7 +55,7 @@ module Barley
       mock = Minitest::Mock.new
       serializer_mock = Minitest::Mock.new
       mock.expect(:class, mock)
-      mock.expect(:new, serializer_mock, [model], cache: true, root: false)
+      mock.expect(:new, serializer_mock, [model], cache: true, root: false, only: nil, except: nil)
       serializer_mock.expect(:serializable_hash, {}, [])
 
       model.stub(:serializer, mock) do
@@ -71,7 +71,7 @@ module Barley
       mock = Minitest::Mock.new
       serializer_mock = Minitest::Mock.new
       mock.expect(:class, mock)
-      mock.expect(:new, serializer_mock, [model], cache: {expires_in: 1.hour}, root: false)
+      mock.expect(:new, serializer_mock, [model], cache: {expires_in: 1.hour}, root: false, only: nil, except: nil)
       serializer_mock.expect(:serializable_hash, {}, [])
 
       model.stub(:serializer, mock) do
@@ -87,11 +87,58 @@ module Barley
       mock = Minitest::Mock.new
       serializer_mock = Minitest::Mock.new
       mock.expect(:class, mock)
-      mock.expect(:new, serializer_mock, [model], cache: false, root: true)
+      mock.expect(:new, serializer_mock, [model], cache: false, root: true, only: nil, except: nil)
       serializer_mock.expect(:serializable_hash, {}, [])
 
       model.stub(:serializer, mock) do
         model.as_json(root: true)
+      end
+
+      mock.verify
+      serializer_mock.verify
+    end
+
+    test "serializer raises error if default serializer is not defined" do
+      assert_raises(Barley::Error) do
+        Class.new do
+          include Barley::Serializable
+        end.new.serializer
+      end
+    end
+
+    test "as_json raises error if custom serializer is not defined" do
+      model = @model.new
+      assert_raises(Barley::Error) do
+        model.as_json
+      end
+    end
+
+    test "as_json with only option calls the serializer with only option" do
+      model = @model.new
+      mock = Minitest::Mock.new
+      serializer_mock = Minitest::Mock.new
+      mock.expect(:class, mock)
+      mock.expect(:new, serializer_mock, [model], cache: false, root: false, only: [:name], except: nil)
+      serializer_mock.expect(:serializable_hash, {}, [])
+
+      model.stub(:serializer, mock) do
+        model.as_json(only: [:name])
+      end
+
+      mock.verify
+      serializer_mock.verify
+    end
+
+    test "as_json with except option calls the serializer with except option" do
+      model = @model.new
+      mock = Minitest::Mock.new
+      serializer_mock = Minitest::Mock.new
+      mock.expect(:class, mock)
+      mock.expect(:new, serializer_mock, [model], cache: false, root: false, only: nil, except: [:name])
+      serializer_mock.expect(:serializable_hash, {}, [])
+
+      model.stub(:serializer, mock) do
+        model.as_json(except: [:name])
       end
 
       mock.verify

--- a/test/barley/serializer_test.rb
+++ b/test/barley/serializer_test.rb
@@ -224,5 +224,222 @@ module Barley
         serializer.new(object).serializable_hash
       end
     end
+
+    test "serializes with a custom attribute and type" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        attribute :age, type: Types::Coercible::Integer do
+          object.profile.age
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        age: @user.profile.age
+      }
+      assert_equal(expected, serializer.new(@user).serializable_hash)
+    end
+
+    test "serializes with a custom attribute and invalid type" do
+      serializer = Class.new(Barley::Serializer) do
+        attribute :age, type: Types::Strict::Integer do
+          "invalid age"
+        end
+      end
+      assert_raises Barley::InvalidAttributeError do
+        serializer.new(@user).serializable_hash
+      end
+    end
+
+    test "serializes with a custom association and cache" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        one :profile, cache: true do
+          attributes :id, :name
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        profile: {
+          id: @user.profile.id,
+          name: @user.profile.name
+        }
+      }
+      assert_equal(expected, serializer.new(@user).serializable_hash)
+    end
+
+    test "serializes with a custom association and invalid cache" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        one :profile, cache: {expires_in: -21.years} do
+          attributes :id, :name
+        end
+      end
+      assert_raises ArgumentError do
+        serializer.new(@user).serializable_hash
+      end
+    end
+
+    test "serializes with a nested association and scope" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups, scope: :active do
+          attributes :id, :name
+
+          many :users do
+            attributes :id, :email
+          end
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        groups: @user.groups.active.map do |g|
+          {
+            id: g.id,
+            name: g.name,
+            users: g.users.map { |u| {id: u.id, email: u.email} }
+          }
+        end
+      }
+      assert_equal(expected, serializer.new(@user).serializable_hash)
+    end
+
+    test "serializes with a nested association and lambda scope" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups, scope: -> { limit(1) } do
+          attributes :id, :name
+
+          many :users do
+            attributes :id, :email
+          end
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        groups: @user.groups.limit(1).map do |g|
+          {
+            id: g.id,
+            name: g.name,
+            users: g.users.map { |u| {id: u.id, email: u.email} }
+          }
+        end
+      }
+      assert_equal(expected, serializer.new(@user).serializable_hash)
+    end
+
+    test "serializes with context passed to a scope" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups, scope: ->(ctx) { limit(ctx.limit) } do
+          attributes :id, :name
+        end
+      end
+      context = Struct.new(:limit).new(1)
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        groups: @user.groups.limit(1).map do |g|
+          {
+            id: g.id,
+            name: g.name
+          }
+        end
+      }
+      assert_equal(expected, serializer.new(@user, context: context).serializable_hash)
+    end
+
+    test "serializes with only specified attributes" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email, :created_at, :updated_at
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email
+      }
+      assert_equal(expected, serializer.new(@user, only: %i[id email]).serializable_hash)
+    end
+
+    test "serializes with except specified attributes" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email, :created_at, :updated_at
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        created_at: @user.created_at
+      }
+      assert_equal(expected, serializer.new(@user, except: [:updated_at]).serializable_hash)
+    end
+
+    test "serializes with only and except combined" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email, :created_at, :updated_at
+      end
+      expected = {
+        id: @user.id
+      }
+      assert_equal(expected, serializer.new(@user, only: %i[id email], except: [:email]).serializable_hash)
+    end
+
+    test "serializes nested associations with only" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups do
+          attributes :id, :name
+
+          many :users do
+            attributes :id, :email
+          end
+        end
+      end
+      expected = {
+        id: @user.id,
+        groups: @user.groups.map do |g|
+          {
+            id: g.id,
+            users: g.users.map { |u| {id: u.id} }
+          }
+        end
+      }
+      assert_equal(expected,
+        serializer.new(@user, only: [:id, {groups: [:id, {users: [:id]}]}]).serializable_hash)
+    end
+
+    test "serializes nested associations with except" do
+      serializer = Class.new(Barley::Serializer) do
+        attributes :id, :email
+
+        many :groups do
+          attributes :id, :name
+
+          many :users do
+            attributes :id, :email
+          end
+        end
+      end
+      expected = {
+        id: @user.id,
+        email: @user.email,
+        groups: @user.groups.map do |g|
+          {
+            id: g.id,
+            name: g.name,
+            users: g.users.map { |u| {id: u.id} }
+          }
+        end
+      }
+      assert_equal(expected, serializer.new(@user, except: [{groups: [{users: [:email]}]}]).serializable_hash)
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR introduces two things:
- `only` and `except` options that can be sent to the serializer's `new` method. They can also be arguments to the `as_json` method on the model. These options are possibly nested.
- Adds the possibility to pass the `context` as an argument to the `scope` lambda / proc on a `many` association. Great for filtering by language, etc.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

